### PR TITLE
feat : 공공데이터 동물 정보 API 불러와서 DB에 저장 #36

### DIFF
--- a/nyang/src/main/java/com/project/nyang/NyangApplication.java
+++ b/nyang/src/main/java/com/project/nyang/NyangApplication.java
@@ -4,7 +4,9 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 @EnableJpaAuditing
 public class NyangApplication {

--- a/nyang/src/main/java/com/project/nyang/global/common/publicapi/PublicAnimalApiClient.java
+++ b/nyang/src/main/java/com/project/nyang/global/common/publicapi/PublicAnimalApiClient.java
@@ -1,0 +1,67 @@
+package com.project.nyang.global.common.publicapi;
+
+import com.project.nyang.modules.animal.dto.AnimalApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.List;
+
+/**
+ * 외부 api를 호출하는 PublicAnimalApiClient 생성합니다.
+ *
+ * @author : 엄아영
+ * @fileName : PublicAnimalApiClient
+ * @since : 2025-07-14
+ */
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PublicAnimalApiClient {
+
+    private final RestTemplate restTemplate;
+    private static final String BASE_URL = "https://apis.data.go.kr/1543061/abandonmentPublicService_v2/abandonmentPublic_v2";
+
+    @Value("${publicapi.service-key}")
+    private String serviceKey;
+
+    public List<AnimalApiResponse> fetchAnimals(String startDate, String endDate, int pageNo, int numOfRows) {
+        String url = UriComponentsBuilder.fromHttpUrl(BASE_URL)
+                .queryParam("serviceKey", serviceKey)
+                .queryParam("bgnde", startDate)
+                .queryParam("endde", endDate)
+                .queryParam("_type", "json")
+                .queryParam("pageNo", pageNo)
+                .queryParam("numOfRows", numOfRows)
+                .build()
+                .toUriString();
+        log.info("Request URL: {}", url);
+
+        ResponseEntity<PublicApiResponse> response = restTemplate.getForEntity(url, PublicApiResponse.class);
+        return response.getBody().getResponse().getBody().getItems().getItem();
+    }
+
+    // updTm 기준으로 가져와서 수정
+    public List<AnimalApiResponse> updateAnimals(String startDate, String endDate, int pageNo, int numOfRows) {
+        String url = UriComponentsBuilder.fromHttpUrl(BASE_URL)
+                .queryParam("serviceKey", serviceKey)
+                .queryParam("bgupd", startDate)
+                .queryParam("enupd", endDate)
+                .queryParam("_type", "json")
+                .queryParam("pageNo", pageNo)
+                .queryParam("numOfRows", numOfRows)
+                .build()
+                .toUriString();
+        log.info("Request URL: {}", url);
+
+        ResponseEntity<PublicApiResponse> response = restTemplate.getForEntity(url, PublicApiResponse.class);
+        return response.getBody().getResponse().getBody().getItems().getItem();
+    }
+
+
+}

--- a/nyang/src/main/java/com/project/nyang/global/common/publicapi/PublicApiResponse.java
+++ b/nyang/src/main/java/com/project/nyang/global/common/publicapi/PublicApiResponse.java
@@ -1,0 +1,41 @@
+package com.project.nyang.global.common.publicapi;
+
+import com.project.nyang.modules.animal.dto.AnimalApiResponse;
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * 공공 API 응답을 매핑하는 PublicApiResponse DTO클래스입니다.
+ *
+ * @author : 엄아영
+ * @fileName : PublicApiResponse
+ * @since : 2025-07-14
+ */
+
+@Data
+public class PublicApiResponse {
+    private Response response;
+
+    @Data
+    public static class Response {
+        private Header header;
+        private Body body;
+    }
+
+    @Data
+    public static class Header {
+        private String resultCode;
+        private String resultMessage;
+    }
+
+    @Data
+    public static class Body {
+        private Items items;
+    }
+
+    @Data
+    public static class Items {
+        private List<AnimalApiResponse> item;
+    }
+}

--- a/nyang/src/main/java/com/project/nyang/global/common/publicapi/RestTemplateConfig.java
+++ b/nyang/src/main/java/com/project/nyang/global/common/publicapi/RestTemplateConfig.java
@@ -1,0 +1,20 @@
+package com.project.nyang.global.common.publicapi;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * RestTemplateConfig입니다.
+ *
+ * @author : 엄아영
+ * @fileName : RestTemplateConfig
+ * @since : 2025-07-14
+ */
+@Configuration
+public class RestTemplateConfig {
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/nyang/src/main/java/com/project/nyang/global/config/springsecurity/SecurityConfig.java
+++ b/nyang/src/main/java/com/project/nyang/global/config/springsecurity/SecurityConfig.java
@@ -57,6 +57,7 @@ public class SecurityConfig {
                                         "/api/v1/boards/**",
                                         "/api/v1/recommendations/**",
                                         "/api/v1/shelters/**",
+                                        "/api/v1/public/**",
                                         "/*"
 
                                 ).permitAll()

--- a/nyang/src/main/java/com/project/nyang/modules/animal/controller/AnimalApiController.java
+++ b/nyang/src/main/java/com/project/nyang/modules/animal/controller/AnimalApiController.java
@@ -1,0 +1,57 @@
+package com.project.nyang.modules.animal.controller;
+
+import com.project.nyang.global.common.publicapi.PublicAnimalApiClient;
+import com.project.nyang.modules.animal.dto.AnimalApiResponse;
+import com.project.nyang.modules.animal.service.AnimalApiService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * AnimalApiController입니다
+ *
+ * @author : 엄아영
+ * @fileName : AnimalApiController
+ * @since : 2025-07-14
+ */
+
+@RestController
+@RequestMapping("/api/v1/public")
+@RequiredArgsConstructor
+public class AnimalApiController {
+
+    private final AnimalApiService animalApiService;
+    private final PublicAnimalApiClient publicAnimalApiClient;
+
+    //테스트
+    @GetMapping("/test")
+    public void testFetchAnimals(@RequestParam String startDate, @RequestParam String endDate) {
+        animalApiService.testFetchAnimals(startDate, endDate);
+    }
+
+    //api 불러와서 db에 저장
+    @GetMapping()
+    public ResponseEntity<String> getPublicAnimals(@RequestParam String startDate, @RequestParam String endDate) {
+        animalApiService.fetchAndSaveAnimals(startDate, endDate);
+        return ResponseEntity.ok("공공데이터 API의 동물 정보를 성공적으로 조회하고 저장하였습니다.");
+    }
+
+    //가장 오래된 날짜의 데이터 삭제
+    @GetMapping("/delete")
+    public ResponseEntity<String> deleteOldestAnimals() {
+        animalApiService.deleteOldestAnimals();
+        return ResponseEntity.ok("가장 오래된 날짜의 동물을 성공적으로 삭제했습니다.");
+    }
+
+    //업데이트 된 api 불러와서 db에 저장
+    @GetMapping("/update")
+    public ResponseEntity<String> getUpdateAnimals(@RequestParam String startDate, @RequestParam String endDate) {
+        animalApiService.updateAnimals(startDate, endDate);
+        return ResponseEntity.ok("공공데이터 API의 동물 정보를 성공적으로 업데이트하였습니다.");
+    }
+}

--- a/nyang/src/main/java/com/project/nyang/modules/animal/controller/AnimalController.java
+++ b/nyang/src/main/java/com/project/nyang/modules/animal/controller/AnimalController.java
@@ -56,8 +56,8 @@ public class AnimalController {
     public ResponseEntity<ApiResponse<Page<AnimalListDTO>>> getFilterAnimals(
             @Parameter(description = "시작일", example = "2025-07-11") @RequestParam(required = false) LocalDate startDate,
             @Parameter(description = "종료일", example = "2025-07-20") @RequestParam(required = false) LocalDate endDate,
-            @Parameter(description = "축종 코드", example = "417000") @RequestParam(required = false) String upKindCd,
-            @Parameter(description = "품종 코드", example = "000139") @RequestParam(required = false) String kindCd,
+            @Parameter(description = "축종 코드") @RequestParam(required = false) String upKindCd,
+            @Parameter(description = "품종 코드") @RequestParam(required = false) String kindCd,
             @Parameter(description = "시도 코드", example = "6260000") @RequestParam(required = false) String regionCode,
             @Parameter(description = "시군구 코드", example = "3340000") @RequestParam(required = false) String subRegionCode,
             @Parameter(description = "페이지 번호", example = "0") @RequestParam(defaultValue = "0") int page,

--- a/nyang/src/main/java/com/project/nyang/modules/animal/controller/AnimalRecommendationController.java
+++ b/nyang/src/main/java/com/project/nyang/modules/animal/controller/AnimalRecommendationController.java
@@ -32,7 +32,7 @@ public class AnimalRecommendationController {
 
     // 이달의 추천 동물
     @Operation(summary = "이달의 추천 동물", description = "오늘 날짜를 기준으로 잔여 공고일이 가장 적은 동물부터, 동률 시 찜(좋아요) 수가 적은 순서로 정렬한다. \n" +
-            "이렇게 우선순위를 적용한 뒤 상위 limit 12마리만 잘라서 응답한다.")
+            "이렇게 우선순위를 적용한 뒤 상위 limit 6마리만 잘라서 응답한다.")
     @GetMapping()
     public ResponseEntity<ApiResponse<List<AnimalListDTO>>> getRecommendAnimals(){
         List<AnimalListDTO> recommendations = animalService.getRecommendAnimals();

--- a/nyang/src/main/java/com/project/nyang/modules/animal/dto/AnimalApiResponse.java
+++ b/nyang/src/main/java/com/project/nyang/modules/animal/dto/AnimalApiResponse.java
@@ -1,0 +1,67 @@
+package com.project.nyang.modules.animal.dto;
+
+import lombok.Data;
+
+/**
+ * 동물 데이터를 매핑하는 AnimalApiResponse DTO클래스 입니다.
+ *
+ * @author : 엄아영
+ * @fileName : AnimalApiResponse
+ * @since : 2025-07-14
+ */
+
+@Data
+public class AnimalApiResponse {
+    //유기 동물 번호
+    private String desertionNo;
+    //발견일
+    private String happenDt;
+    //발견 장소
+    private String happenPlace;
+    //동물 종류 전체 이름 ex.[개] 시바
+    private String kindFullNm;
+    private String upKindCd;
+    private String upKindNm;
+    private String kindCd;
+    private String kindNm;
+    //털색, 무늬
+    private String colorCd;
+    //나이
+    private String age;
+    //무게
+    private String weight;
+    //공고 번호
+    private String noticeNo;
+    //공고 시작
+    private String noticeSdt;
+    //공고 종료
+    private String noticeEdt;
+    //이미지 1
+    private String popfile1;
+    //이미지 2
+    private String popfile2;
+    //이미지 3
+    private String popfile3;
+    //보호상태 (NOTICE / PROTECT / FINISH)
+    private String processState;
+    // 성별 (M / F / Q)
+    private String sexCd;
+    //중성화 여부 (Y / N / U)
+    private String neuterYn;
+    //특이 사항
+    private String specialMark;
+    //보호소 번호
+    private String careRegNo;
+    //보호소 이름
+    private String careNm;
+    //보호소 전화번호
+    private String careTel;
+    //보호소 주소
+    private String careAddr;
+    //보호소 장 이름
+    private String careOwnerNm;
+    //보호소 시도, 시군구 이름
+    private String orgNm;
+    //API 수정 시각
+    private String updTm;
+}

--- a/nyang/src/main/java/com/project/nyang/modules/animal/entity/Animal.java
+++ b/nyang/src/main/java/com/project/nyang/modules/animal/entity/Animal.java
@@ -1,10 +1,8 @@
 package com.project.nyang.modules.animal.entity;
 
-import com.project.nyang.global.common.entity.BaseTime;
 import com.project.nyang.modules.comment.entity.Comment;
 import com.project.nyang.modules.shelter.entity.Shelter;
 import com.project.nyang.reference.entity.Kind;
-import com.project.nyang.reference.entity.SubRegion;
 import com.project.nyang.reference.entity.UpKind;
 import jakarta.persistence.*;
 import lombok.*;
@@ -46,6 +44,12 @@ public class Animal{
     //동물 종류 전체 이름 ex.[개] 시바
     @Column(name = "kind_full_nm", length = 50)
     private String kindFullNm;
+
+    @Column(name = "up_kind_cd")
+    private String upKindCd;
+
+    @Column(name = "kind_cd")
+    private String kindCd;
 
     //털색, 무늬
     @Column(name = "color_cd", length = 40)
@@ -120,4 +124,28 @@ public class Animal{
     @OneToMany(mappedBy = "animal", fetch = FetchType.LAZY, cascade =  CascadeType.ALL)
     private List<Comment> comment = new ArrayList<>();
 
+    public void updateFrom(Animal updated) {
+        this.shelter = updated.getShelter();
+        this.upKind = updated.getUpKind();
+        this.kind = updated.getKind();
+        this.upKindCd = updated.getUpKindCd();
+        this.kindCd = updated.getKindCd();
+        this.happenDt = updated.getHappenDt();
+        this.noticeSdt = updated.getNoticeSdt();
+        this.noticeEdt = updated.getNoticeEdt();
+        this.happenPlace = updated.getHappenPlace();
+        this.kindFullNm = updated.getKindFullNm();
+        this.colorCd = updated.getColorCd();
+        this.age = updated.getAge();
+        this.weight = updated.getWeight();
+        this.noticeNo = updated.getNoticeNo();
+        this.popfile1 = updated.getPopfile1();
+        this.popfile2 = updated.getPopfile2();
+        this.popfile3 = updated.getPopfile3();
+        this.processState = updated.getProcessState();
+        this.sexCd = updated.getSexCd();
+        this.neuterYn = updated.getNeuterYn();
+        this.specialMark = updated.getSpecialMark();
+        this.updTm = updated.getUpdTm();
+    }
 }

--- a/nyang/src/main/java/com/project/nyang/modules/animal/repository/AnimalRepository.java
+++ b/nyang/src/main/java/com/project/nyang/modules/animal/repository/AnimalRepository.java
@@ -13,6 +13,7 @@ import org.springframework.data.repository.query.Param;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * AnimalRepository입니다
@@ -123,6 +124,25 @@ public interface AnimalRepository extends JpaRepository<Animal, String> {
         DATEDIFF(a.noticeEdt, CURRENT_DATE) ASC, 
         COUNT(l.likeId) ASC,
         FUNCTION('RAND')
-""")
+    """)
     List<AnimalListDTO> findRecommendAnimals(Pageable pageable);
+
+    //DB에 있는 모든 유기동물 찾기
+    @Query("""
+        SELECT a.desertionNo FROM Animal a
+    """)
+    List<String> findAllDesertionNos();
+
+    //가장 오래된 발견 일자 찾기
+    @Query("""
+        SELECT MIN(a.happenDt) FROM Animal a
+    """)
+    LocalDate findOldestHappenDt();
+
+    // 가장 오래된 발견일자의 모든 동물 정보 불러오기
+    List<Animal> findAllByHappenDt(LocalDate oldestDate);
+
+
+    List<Animal> findByDesertionNoIn(Set<String> desertionNos);
+
 }

--- a/nyang/src/main/java/com/project/nyang/modules/animal/scheduler/AnimalDataScheduler.java
+++ b/nyang/src/main/java/com/project/nyang/modules/animal/scheduler/AnimalDataScheduler.java
@@ -1,0 +1,63 @@
+package com.project.nyang.modules.animal.scheduler;
+
+import com.project.nyang.modules.animal.controller.AnimalApiController;
+import com.project.nyang.modules.animal.service.AnimalApiService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * AnimalDataScheduler입니다
+ *
+ * @author : 엄아영
+ * @fileName : AnimalDataScheduler
+ * @since : 2025-07-15
+ */
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AnimalDataScheduler {
+
+    private final AnimalApiService animalApiService;
+    private final AnimalApiController animalApiController;
+
+    @Scheduled(cron = "0 0 1 * * *")
+    public void refreshDailyData() {
+        LocalDate today = LocalDate.now();
+        String todayStr = today.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        log.info("01시 스케줄링 - 오늘 데이터 수집 : {}", todayStr);
+
+        animalApiService.fetchAndSaveAnimals(todayStr, todayStr);
+        animalApiService.updateAnimals(todayStr, todayStr);
+
+        //가장 오래된 데이터 삭제하기
+        animalApiService.deleteOldestAnimals();
+    }
+
+    @Scheduled(cron = "0 0 13 * * *")
+    public void refreshDailyDataAfternoon() {
+        LocalDate today = LocalDate.now();
+        String todayStr = today.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        log.info("13시 스케줄링 - 오늘 데이터 수집 : {}", todayStr);
+
+        animalApiService.fetchAndSaveAnimals(todayStr, todayStr);
+        animalApiService.updateAnimals(todayStr, todayStr);
+    }
+
+    //스케줄링 테스트
+//    @Scheduled(cron = "*/30 * * * * *")  // 매 30초마다
+//    public void refreshSecondData() {
+//        LocalDate today = LocalDate.now();
+//        String todayStr = today.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+//        log.info("30초씩 스케줄링 - 오늘 데이터 수집 : {}", todayStr);
+//
+//        animalApiService.fetchAndSaveAnimals(todayStr, todayStr);
+//        animalApiService.updateAnimals(todayStr, todayStr);
+//    }
+}

--- a/nyang/src/main/java/com/project/nyang/modules/animal/service/AnimalApiService.java
+++ b/nyang/src/main/java/com/project/nyang/modules/animal/service/AnimalApiService.java
@@ -1,0 +1,277 @@
+package com.project.nyang.modules.animal.service;
+
+import com.project.nyang.global.common.publicapi.PublicAnimalApiClient;
+import com.project.nyang.modules.animal.dto.AnimalApiResponse;
+import com.project.nyang.modules.animal.entity.Animal;
+import com.project.nyang.modules.animal.repository.AnimalRepository;
+import com.project.nyang.modules.shelter.entity.Shelter;
+import com.project.nyang.modules.shelter.repository.ShelterRepository;
+import com.project.nyang.reference.entity.Kind;
+import com.project.nyang.reference.entity.UpKind;
+import com.project.nyang.reference.repository.KindRepository;
+import com.project.nyang.reference.repository.UpkindRepository;
+import jakarta.annotation.PostConstruct;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+
+/**
+ * AnimalApiService입니다.
+ *
+ * @author : 엄아영
+ * @fileName : AnimalApiService
+ * @since : 2025-07-14
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AnimalApiService {
+
+    private final PublicAnimalApiClient publicAnimalApiClient;
+    private final AnimalRepository animalRepository;
+    private final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMMdd");
+    private  final DateTimeFormatter updTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.S");
+    private final ShelterRepository shelterRepository;
+    private final UpkindRepository upkindRepository;
+    private final KindRepository kindRepository;
+
+    //api 불러오는지 test
+    @Transactional
+    public void testFetchAnimals(String startDate, String endDate) {
+        List<AnimalApiResponse> apiResponses = publicAnimalApiClient.fetchAnimals(startDate, endDate, 1, 1000);
+
+        for (AnimalApiResponse response : apiResponses) {
+            System.out.println("응답 데이터: " + response);
+        }
+    }
+
+    //최초 16일치 데이터 가져오기
+    @PostConstruct
+    public void initialize() {
+        LocalDate endDate = LocalDate.now();
+        LocalDate startDate = endDate.minusDays(15);
+        String startDateStr = startDate.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        String endDateStr = endDate.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+
+        fetchAndSaveAnimals(startDateStr, endDateStr);
+    }
+
+    //불러와서 animal에 저장
+    @Transactional
+    public void fetchAndSaveAnimals(String startDate, String endDate) {
+        int pageNo = 1;
+        int numOfRows = 1000;
+        boolean hasMoreData = true;
+
+        // Shelter, UpKind, Kind 캐싱
+        Map<String, Shelter> shelterMap = shelterRepository.findAll().stream()
+                .collect(Collectors.toMap(Shelter::getCareRegNumber, Function.identity()));
+
+        Map<String, UpKind> upKindMap = upkindRepository.findAll().stream()
+                .collect(Collectors.toMap(UpKind::getUpKindCd, Function.identity()));
+
+        Map<String, Kind> kindMap = kindRepository.findAll().stream()
+                .collect(Collectors.toMap(Kind::getKindCd, Function.identity()));
+
+        while (hasMoreData) {
+            List<AnimalApiResponse> apiResponses = publicAnimalApiClient.fetchAnimals(startDate, endDate, pageNo, numOfRows);
+
+            if (apiResponses.isEmpty()) {
+                hasMoreData = false;
+                break;
+            }
+
+            // API 응답에서 desertionNo Set 생성
+            Set<String> incomingDesertionNos = apiResponses.stream()
+                    .map(AnimalApiResponse::getDesertionNo)
+                    .collect(Collectors.toSet());
+
+            // DB에서 desertionNo 일괄 조회
+            Map<String, Animal> existingAnimalsMap = animalRepository.findByDesertionNoIn(incomingDesertionNos)
+                    .stream()
+                    .collect(Collectors.toMap(Animal::getDesertionNo, Function.identity()));
+
+            List<Animal> animalsToSave = new ArrayList<>();
+
+            for (AnimalApiResponse apiResponse : apiResponses) {
+                Animal newAnimal = convertToAnimalEntity(apiResponse, shelterMap, upKindMap, kindMap);
+                if (newAnimal == null) continue;
+
+                Animal existingAnimal = existingAnimalsMap.get(apiResponse.getDesertionNo());
+                if (existingAnimal != null) {
+                    existingAnimal.updateFrom(newAnimal); // 수정
+                    animalsToSave.add(existingAnimal);
+                } else {
+                    animalsToSave.add(newAnimal); // 신규
+                }
+            }
+
+            if (!animalsToSave.isEmpty()) {
+                animalRepository.saveAll(animalsToSave);
+                log.info("저장 및 수정 {} animals to DB on page {}", animalsToSave.size(), pageNo);
+            }
+
+            if (apiResponses.size() < numOfRows) {
+                hasMoreData = false;
+            } else {
+                pageNo++;
+            }
+        }
+    }
+
+    //업데이트
+    @Transactional
+    public void updateAnimals(String startDate, String endDate) {
+        int pageNo = 1;
+        int numOfRows = 1000;
+        boolean hasMoreData = true;
+
+        //db에서 가장 오래된 발견일 날짜 조회
+        LocalDate oldestDate = animalRepository.findOldestHappenDt();
+        if (oldestDate == null) {
+            oldestDate = LocalDate.MIN; // DB에 아무 데이터가 없는 경우
+        }
+
+        // Shelter, UpKind, Kind 캐싱
+        Map<String, Shelter> shelterMap = shelterRepository.findAll().stream()
+                .collect(Collectors.toMap(Shelter::getCareRegNumber, Function.identity()));
+
+        Map<String, UpKind> upKindMap = upkindRepository.findAll().stream()
+                .collect(Collectors.toMap(UpKind::getUpKindCd, Function.identity()));
+
+        Map<String, Kind> kindMap = kindRepository.findAll().stream()
+                .collect(Collectors.toMap(Kind::getKindCd, Function.identity()));
+
+        while (hasMoreData) {
+            List<AnimalApiResponse> apiResponses = publicAnimalApiClient.updateAnimals(startDate, endDate, pageNo, numOfRows);
+
+            if (apiResponses.isEmpty()) {
+                hasMoreData = false;
+                break;
+            }
+
+            // API 응답에서 desertionNo Set 생성
+            Set<String> incomingDesertionNos = apiResponses.stream()
+                    .map(AnimalApiResponse::getDesertionNo)
+                    .collect(Collectors.toSet());
+
+            // DB에서 desertionNo 일괄 조회
+            Map<String, Animal> existingAnimalsMap = animalRepository.findByDesertionNoIn(incomingDesertionNos)
+                    .stream()
+                    .collect(Collectors.toMap(Animal::getDesertionNo, Function.identity()));
+
+            List<Animal> animalsToSave = new ArrayList<>();
+
+            for (AnimalApiResponse apiResponse : apiResponses) {
+                String happenDtStr = apiResponse.getHappenDt();
+                LocalDate happenDt = LocalDate.parse(happenDtStr, dateTimeFormatter);
+                if (happenDt.isBefore(oldestDate)) {
+                    continue; // 과거 데이터면 skip
+                }
+
+                Animal newAnimal = convertToAnimalEntity(apiResponse, shelterMap, upKindMap, kindMap);
+                if (newAnimal == null) continue;
+
+                Animal existingAnimal = existingAnimalsMap.get(apiResponse.getDesertionNo());
+                if (existingAnimal != null) {
+                    existingAnimal.updateFrom(newAnimal); // 수정
+                    animalsToSave.add(existingAnimal);
+                } else {
+                    animalsToSave.add(newAnimal); // 신규
+                }
+            }
+
+            if (!animalsToSave.isEmpty()) {
+                animalRepository.saveAll(animalsToSave);
+                log.info("업데이트 {} animals to DB on page {}", animalsToSave.size(), pageNo);
+            }
+
+            if (apiResponses.size() < numOfRows) {
+                hasMoreData = false;
+            } else {
+                pageNo++;
+            }
+        }
+    }
+
+    // AnimalEntity로 변환
+    private Animal convertToAnimalEntity(AnimalApiResponse response,
+                                         Map<String, Shelter> shelterMap,
+                                         Map<String, UpKind> upKindMap,
+                                         Map<String, Kind> kindMap) {
+
+        Shelter shelter = shelterMap.get(response.getCareRegNo());
+        if (shelter == null) {
+            log.warn("Shelter not found: {}", response.getCareRegNo());
+            return null;
+        }
+
+        UpKind upKind = upKindMap.get(response.getUpKindCd());
+        if (upKind == null) {
+            log.warn("UpKind not found: {}", response.getUpKindCd());
+            return null;
+        }
+
+        Kind kind = kindMap.get(response.getKindCd());
+        if (kind == null) {
+            log.warn("Kind not found: {}", response.getKindCd());
+            return null;
+        }
+
+        return Animal.builder()
+                .desertionNo(response.getDesertionNo())
+                .shelter(shelter)
+                .upKind(upKind)
+                .kind(kind)
+                .upKindCd(upKind.getUpKindCd())
+                .kindCd(kind.getKindCd())
+                .happenDt(LocalDate.parse(response.getHappenDt(), dateTimeFormatter))
+                .noticeSdt(LocalDate.parse(response.getNoticeSdt(), dateTimeFormatter))
+                .noticeEdt(LocalDate.parse(response.getNoticeEdt(), dateTimeFormatter))
+                .happenPlace(response.getHappenPlace())
+                .kindFullNm(response.getKindFullNm())
+                .colorCd(response.getColorCd())
+                .age(response.getAge())
+                .weight(response.getWeight())
+                .noticeNo(response.getNoticeNo())
+                .popfile1(response.getPopfile1())
+                .popfile2(response.getPopfile2())
+                .popfile3(response.getPopfile3())
+                .processState(response.getProcessState())
+                .sexCd(response.getSexCd())
+                .neuterYn(response.getNeuterYn())
+                .specialMark(response.getSpecialMark())
+                .updTm(LocalDateTime.parse(response.getUpdTm(), updTimeFormatter))
+                .build();
+    }
+
+    //오래된 동물 정보 삭제
+    @Transactional
+    public void deleteOldestAnimals() {
+        // 가장 오래된 happenDt 조회
+        LocalDate oldestDate = animalRepository.findOldestHappenDt();
+        if (oldestDate == null) {
+            log.info("삭제할 오래된 데이터가 없습니다.");
+            return;
+        }
+
+        // 해당 happenDt를 가진 Animal 모두 조회
+        List<Animal> oldestAnimals = animalRepository.findAllByHappenDt(oldestDate);
+
+        // 삭제
+        animalRepository.deleteAll(oldestAnimals);
+        log.info("Deleted {} animals with happenDt: {}", oldestAnimals.size(), oldestDate);
+    }
+
+
+
+}

--- a/nyang/src/main/java/com/project/nyang/modules/animal/service/AnimalService.java
+++ b/nyang/src/main/java/com/project/nyang/modules/animal/service/AnimalService.java
@@ -132,6 +132,6 @@ public class AnimalService {
 
     @Transactional
     public List<AnimalListDTO> getRecommendAnimals() {
-        return animalRepository.findRecommendAnimals(PageRequest.of(0, 12));
+        return animalRepository.findRecommendAnimals(PageRequest.of(0, 6));
     }
 }

--- a/nyang/src/main/java/com/project/nyang/modules/shelter/repository/ShelterRepository.java
+++ b/nyang/src/main/java/com/project/nyang/modules/shelter/repository/ShelterRepository.java
@@ -92,4 +92,7 @@ public interface ShelterRepository extends JpaRepository<Shelter, String> {
     Optional<ShelterDetailDTO> findDetailByCareRegNumber(String careRegNumber);
 
 
+    //동물 api에서 보호소 번호 찾아오기
+    Optional<Shelter> findByCareRegNumber(String careRegNumber);
+
 }

--- a/nyang/src/main/java/com/project/nyang/reference/repository/KindRepository.java
+++ b/nyang/src/main/java/com/project/nyang/reference/repository/KindRepository.java
@@ -15,4 +15,6 @@ import java.util.Optional;
  */
 public interface KindRepository extends JpaRepository<Kind,String> {
     Optional<Kind> findByKindNm(String kindNm);
+
+
 }

--- a/nyang/src/main/java/com/project/nyang/reference/repository/UpkindRepository.java
+++ b/nyang/src/main/java/com/project/nyang/reference/repository/UpkindRepository.java
@@ -14,4 +14,7 @@ import java.util.Optional;
  */
 public interface UpkindRepository extends JpaRepository<UpKind,String> {
     Optional<UpKind> findByUpKindNm(String upKindNm);
+
+    Optional<UpKind> findByUpKindCd(String upKindCd);
+
 }

--- a/nyang/src/main/resources/application.yaml
+++ b/nyang/src/main/resources/application.yaml
@@ -1,6 +1,13 @@
 spring:
   profiles:
     active: dev
+  jpa:
+    properties:
+      hibernate:
+        jdbc:
+          batch_size: 100
+        order_inserts: true
+        order_updates: true
 
   jackson:
     serialization:
@@ -64,3 +71,6 @@ jwt:
   secretKey: ${JWT_SECRET_KEY}
   accessTokenExpirationTime: 900000          # 15분 (밀리초 기준)
   refreshTokenExpirationTime: 1209600000     # 14일
+
+publicapi:
+  service-key: ${publicapi.service-key}


### PR DESCRIPTION
- 공공API 동물정보 불러와서 DB에 저장
- 처음 어플리케이션 구동할 때 오늘로부터 16일 데이터 저장
- 매일 오전1시, 13시에 작업스케줄링
- 매일 오전 1시에 가장 오래된 날짜 동물정보 삭제